### PR TITLE
fix(footer): chat link href

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
             </svg>
             <span className="sr-only">(opens in a new tab)</span>
           </a>
-          <Link href="/chat" className="text-sm text-gray-400 hover:text-white transition-colors">Chat</Link>
+          <Link href="https://chat.routstr.com" className="text-sm text-gray-400 hover:text-white transition-colors">Chat</Link>
           <Link href="/roadmap" className="text-sm text-gray-400 hover:text-white transition-colors">Roadmap</Link>
           <Link href="/privacy" className="text-sm text-gray-400 hover:text-white transition-colors">Privacy</Link>
           <Link href="/terms" className="text-sm text-gray-400 hover:text-white transition-colors">Terms</Link>


### PR DESCRIPTION
### Before

<img width="714" alt="image" src="https://github.com/user-attachments/assets/1a14022f-9cd2-4a40-8534-7f93bea4ce9f" />

`https://www.routstr.com/chat`

### After

<img width="963" alt="image" src="https://github.com/user-attachments/assets/bb605ec0-8084-497a-871e-aa3df9f5113a" />

`https://chat.routstr.com/`